### PR TITLE
Configures Cognito to use SES for email

### DIFF
--- a/Terraform/local/cognito/variables.tf
+++ b/Terraform/local/cognito/variables.tf
@@ -3,3 +3,5 @@ variable "project_readable_name" {}
 variable "project_name" {}
 
 variable "environment" {}
+
+variable "domain" {}

--- a/Terraform/local/main.tf
+++ b/Terraform/local/main.tf
@@ -21,6 +21,7 @@ module "cognito" {
   project_readable_name = var.project_readable_name
   project_name          = var.project_name
   environment           = var.environment
+  domain                = var.domain
 }
 
 module "iam" {

--- a/Terraform/local/variables.tf
+++ b/Terraform/local/variables.tf
@@ -32,3 +32,9 @@ variable "account_id" {
   description = "The account ID of the project."
   type        = string
 }
+
+variable "domain" {
+  description = "The domain of the project."
+  type        = string
+  default     = "getwillowsuite.com"
+}


### PR DESCRIPTION
Configures Cognito to use SES for sending emails,
allowing for a custom "from" email address and
improved email deliverability. This includes setting up an SES identity policy to grant Cognito permission to send emails on behalf of the domain.